### PR TITLE
Update main.go

### DIFF
--- a/chap1/manual-parse/main.go
+++ b/chap1/manual-parse/main.go
@@ -24,7 +24,7 @@ func printUsage(w io.Writer) {
 }
 
 func validateArgs(c config) error {
-	if !(c.numTimes > 0) {
+	if c.numTimes <= 0 && !c.printUsage {
 		return errors.New("Must specify a number greater than 0")
 	}
 	return nil


### PR DESCRIPTION
Fix for https://github.com/practicalgo/code/issues/5
to fix issue alway print message "Must specify a number greater than 0" when user want to see help