### PR TITLE
CI - Replace go get by go install

### DIFF
--- a/.github/workflows/golint_test.yml
+++ b/.github/workflows/golint_test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Run golint
       run: |
-        go get -u golang.org/x/lint/golint
+        go install golang.org/x/lint/golint@latest
         python housekeeping/golint.py .
   vet:
     name: Vet


### PR DESCRIPTION
https://go.dev/doc/go-get-install-deprecation